### PR TITLE
 Fix database migration crash on upgrade

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -11,8 +11,8 @@ android {
         applicationId "com.github.igrmk.smsq"
         minSdkVersion 19
         targetSdkVersion 28
-        versionCode 17
-        versionName "1.7.0"
+        versionCode 18
+        versionName "1.7.1"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true
     }

--- a/android/app/src/main/java/com/github/igrmk/smsq/helpers/Database.kt
+++ b/android/app/src/main/java/com/github/igrmk/smsq/helpers/Database.kt
@@ -45,7 +45,13 @@ class DbHelper(ctx: Context) : ManagedSQLiteOpenHelper(ctx, "database", version 
     }
 
     override fun onUpgrade(db: SQLiteDatabase, oldVersion: Int, newVersion: Int) {
-        onCreate(db)
+        if (oldVersion < 18) {
+            try {
+                db.execSQL("ALTER TABLE $TABLE_SMS ADD COLUMN $COLUMN_SMS_TYPE TEXT DEFAULT 'sms'")
+            } catch (e: Exception) {
+                // Column already exists
+            }
+        }
     }
 }
 


### PR DESCRIPTION
 Add migration to create 'type' column for existing installations.
 Users upgrading from 1.6.x were crashing due to missing column.

 Bump version to 1.7.1


Fixes issue #7 